### PR TITLE
fix: update paths in templates and documentation to reflect new folder structure

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -11,7 +11,7 @@
 - [爬取并导入学者信息到 PaperBell](scholar/README.md)
 - [剪藏豆瓣读书 / 电影条目到 PaperBell](douban/README.md)
 
-所有模板都剪藏到 `Inputs`——PaperBell 监视的文件夹，再由其按 frontmatter 归档。
+所有模板都剪藏到 `20 - Inputs`——PaperBell 监视的文件夹，再由其按 frontmatter 归档。
 
 ## 贡献指南
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ To install a template, see the official [Obsidian Web Clipper documentation](htt
 - [Scholar](scholar/README.md) — clip a scholar's profile and import it into PaperBell.
 - [Douban](douban/README.md) — clip a Douban book or movie entry into PaperBell.
 
-Every template clips into `Inputs`, the folder PaperBell watches, and is filed from there by frontmatter.
+Every template clips into `20 - Inputs`, the folder PaperBell watches, and is filed from there by frontmatter.
 
 ## Contribution
 

--- a/douban/README.md
+++ b/douban/README.md
@@ -11,7 +11,7 @@
 
 比学者模板轻得多，正文为空，只写 frontmatter，所以对插件几乎没有依赖。请确保：
 
-- 笔记默认保存路径为 `Inputs`——本仓库所有模板都剪藏到这里，也就是 PaperBell 默认监视的 `watchFolder`，再由「按 frontmatter 移动」根据 `input_type` / `tags` 归档到位。如需改动可调整模板的 `path` 字段，但把它挪出 `watchFolder` 会导致剪藏的笔记不再被后处理。
+- 笔记默认保存路径为 `20 - Inputs`——本仓库所有模板都剪藏到这里，也就是 PaperBell 默认监视的 `watchFolder`，再由「按 frontmatter 移动」根据 `input_type` / `tags` 归档到位。如需改动可调整模板的 `path` 字段，但把它挪出 `watchFolder` 会导致剪藏的笔记不再被后处理。
 - `banner` / `banner_icon` 字段供支持横幅的主题或插件（如 Banners）使用；没装也不影响，只是多两个用不上的 frontmatter 字段。
 
 ## Frontmatter 字段（schema）

--- a/douban/douban-book-clipper.json
+++ b/douban/douban-book-clipper.json
@@ -99,6 +99,6 @@
 		"https://book.douban.com/subject/"
 	],
 	"noteNameFormat": "{{meta:property:og:title}}",
-	"path": "Inputs",
+	"path": "20 - Inputs",
 	"context": ""
 }

--- a/douban/douban-movie-clipper.json
+++ b/douban/douban-movie-clipper.json
@@ -99,6 +99,6 @@
 		"https://movie.douban.com/subject/"
 	],
 	"noteNameFormat": "{{meta:property:og:title}}",
-	"path": "Inputs",
+	"path": "20 - Inputs",
 	"context": ""
 }

--- a/schema/clipper-template.schema.json
+++ b/schema/clipper-template.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/PaperBell-Org/paperbell-clippers/schema/clipper-template.schema.json",
   "title": "PaperBell Obsidian Web Clipper template",
-  "description": "Shape of a template JSON in this repo. Stricter than upstream Obsidian Web Clipper on purpose: this repo pins schemaVersion and requires every template to clip into Inputs, the folder PaperBell watches.",
+  "description": "Shape of a template JSON in this repo. Stricter than upstream Obsidian Web Clipper on purpose: this repo pins schemaVersion and requires every template to clip into 20 - Inputs, the folder PaperBell watches.",
   "type": "object",
   "additionalProperties": false,
   "required": [
@@ -35,8 +35,8 @@
     "noteContentFormat": { "type": "string", "minLength": 1 },
     "noteNameFormat": { "type": "string", "minLength": 1 },
     "path": {
-      "const": "Inputs",
-      "description": "Repo policy: every PaperBell clipper lands in Inputs, which PaperBell watches and files by frontmatter."
+      "const": "20 - Inputs",
+      "description": "Repo policy: every PaperBell clipper lands in 20 - Inputs, which PaperBell watches and files by frontmatter."
     },
     "context": { "type": "string" },
     "vault": { "type": "string" },

--- a/scholar/README.md
+++ b/scholar/README.md
@@ -14,7 +14,7 @@
   - **Dataview**（需开启 JavaScript 查询）—— 「最新动态」区使用 `dataviewjs` 扫描日记；其中日记路径 `00 - 每日日记/DailyNote` 为硬编码，请按你的库结构修改。
   - **Bases** —— 「相关论文」区通过 `![[论文检索.base]]` 嵌入，需要库中存在该 base 文件。
   - **Callout（`update` 类型）** —— 「动态日志」区用 `> [!update]` 记录学者的外部更新。
-- 笔记默认保存路径为 `Inputs`——本仓库所有模板都剪藏到这里，也就是 PaperBell 默认监视的 `watchFolder`，再由「按 frontmatter 移动」根据 `scholar` 标签归档到位。如需改动可调整模板的 `path` 字段，但把它挪出 `watchFolder` 会导致剪藏的笔记不再被后处理。
+- 笔记默认保存路径为 `20 - Inputs`——本仓库所有模板都剪藏到这里，也就是 PaperBell 默认监视的 `watchFolder`，再由「按 frontmatter 移动」根据 `scholar` 标签归档到位。如需改动可调整模板的 `path` 字段，但把它挪出 `watchFolder` 会导致剪藏的笔记不再被后处理。
 - 正文含一个指向 `[[学者刷新工作流]]` 的库内链接（记录动态刷新约定），未建该笔记时链接为空链，不影响其他内容。
 
 ## Frontmatter 字段（schema）

--- a/scholar/scholar-clipper.json
+++ b/scholar/scholar-clipper.json
@@ -110,6 +110,6 @@
 		"/^https?:\\/\\/[^\\/?#]+\\.(?:edu(?:\\.[a-z]{2})?|ac\\.[a-z]{2}|mpg\\.de)\\/(?:[^?#]*\\/)?(?:people|person|persons|profile|profiles|faculty|staff|teacher|teachers|members?|szdw|jsdw|rcdw)(?:[\\/?]|\\.html?|$)/"
 	],
 	"noteNameFormat": "{{\"当前学者的名与姓\"}}",
-	"path": "Inputs",
+	"path": "20 - Inputs",
 	"context": "请阅读 {{fullHtml}} 并填写所需的各项信息。注意：在 Google Scholar 等聚合页面上，页面可能同时包含当前登录用户的账号信息（如其 Gmail 地址），请只提取被展示学者本人的信息，忽略浏览者本人的账号。"
 }


### PR DESCRIPTION
Changed all references from `Inputs` to `20 - Inputs` in README files and JSON templates to ensure consistency with the updated folder structure used by PaperBell. This includes updates in the douban and scholar templates, as well as relevant documentation.