### PR TITLE
fix(scholar): clip straight into 30 - Metadata/Scholars

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -11,7 +11,7 @@
 - [爬取并导入学者信息到 PaperBell](scholar/README.md)
 - [剪藏豆瓣读书 / 电影条目到 PaperBell](douban/README.md)
 
-所有模板都剪藏到 `20 - Inputs`——PaperBell 监视的文件夹，再由其按 frontmatter 归档。
+多数模板剪藏到 `20 - Inputs`——PaperBell 监视的文件夹，再由其按 frontmatter 归档。学者模板是例外：它直接写入 `30 - Metadata/Scholars`，因为交给 frontmatter 归档只会把它放进 `20 - Inputs/Clippings`。
 
 ## 贡献指南
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ To install a template, see the official [Obsidian Web Clipper documentation](htt
 - [Scholar](scholar/README.md) — clip a scholar's profile and import it into PaperBell.
 - [Douban](douban/README.md) — clip a Douban book or movie entry into PaperBell.
 
-Every template clips into `20 - Inputs`, the folder PaperBell watches, and is filed from there by frontmatter.
+Most templates clip into `20 - Inputs`, the folder PaperBell watches, and are filed from there by frontmatter. The scholar template is the exception: it writes straight to `30 - Metadata/Scholars`, because frontmatter routing would file it under `20 - Inputs/Clippings` instead.
 
 ## Contribution
 

--- a/douban/README.md
+++ b/douban/README.md
@@ -11,7 +11,7 @@
 
 比学者模板轻得多，正文为空，只写 frontmatter，所以对插件几乎没有依赖。请确保：
 
-- 笔记默认保存路径为 `20 - Inputs`——本仓库所有模板都剪藏到这里，也就是 PaperBell 默认监视的 `watchFolder`，再由「按 frontmatter 移动」根据 `input_type` / `tags` 归档到位。如需改动可调整模板的 `path` 字段，但把它挪出 `watchFolder` 会导致剪藏的笔记不再被后处理。
+- 笔记默认保存路径为 `20 - Inputs`——也就是 PaperBell 默认监视的 `watchFolder`，再由「按 frontmatter 移动」根据 `input_type` / `tags` 归档到位。如需改动可调整模板的 `path` 字段，但把它挪出 `watchFolder` 会导致剪藏的笔记不再被后处理。
 - `banner` / `banner_icon` 字段供支持横幅的主题或插件（如 Banners）使用；没装也不影响，只是多两个用不上的 frontmatter 字段。
 
 ## Frontmatter 字段（schema）

--- a/schema/clipper-template.schema.json
+++ b/schema/clipper-template.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/PaperBell-Org/paperbell-clippers/schema/clipper-template.schema.json",
   "title": "PaperBell Obsidian Web Clipper template",
-  "description": "Shape of a template JSON in this repo. Stricter than upstream Obsidian Web Clipper on purpose: this repo pins schemaVersion and requires every template to clip into 20 - Inputs, the folder PaperBell watches.",
+  "description": "Shape of a template JSON in this repo. Stricter than upstream Obsidian Web Clipper on purpose: this repo pins schemaVersion and restricts path to the folders PaperBell expects.",
   "type": "object",
   "additionalProperties": false,
   "required": [
@@ -35,8 +35,8 @@
     "noteContentFormat": { "type": "string", "minLength": 1 },
     "noteNameFormat": { "type": "string", "minLength": 1 },
     "path": {
-      "const": "20 - Inputs",
-      "description": "Repo policy: every PaperBell clipper lands in 20 - Inputs, which PaperBell watches and files by frontmatter."
+      "enum": ["20 - Inputs", "30 - Metadata/Scholars"],
+      "description": "Repo policy: a clipper either lands in 20 - Inputs, which PaperBell watches and files by frontmatter, or writes straight to its final folder when frontmatter routing cannot get it there (scholar notes belong in 30 - Metadata/Scholars, but Inputs Bell would file them under 20 - Inputs/Clippings)."
     },
     "context": { "type": "string" },
     "vault": { "type": "string" },

--- a/scholar/README.md
+++ b/scholar/README.md
@@ -14,7 +14,7 @@
   - **Dataview**（需开启 JavaScript 查询）—— 「最新动态」区使用 `dataviewjs` 扫描日记；其中日记路径 `00 - 每日日记/DailyNote` 为硬编码，请按你的库结构修改。
   - **Bases** —— 「相关论文」区通过 `![[论文检索.base]]` 嵌入，需要库中存在该 base 文件。
   - **Callout（`update` 类型）** —— 「动态日志」区用 `> [!update]` 记录学者的外部更新。
-- 笔记默认保存路径为 `20 - Inputs`——本仓库所有模板都剪藏到这里，也就是 PaperBell 默认监视的 `watchFolder`，再由「按 frontmatter 移动」根据 `scholar` 标签归档到位。如需改动可调整模板的 `path` 字段，但把它挪出 `watchFolder` 会导致剪藏的笔记不再被后处理。
+- 笔记默认保存路径为 `30 - Metadata/Scholars`——学者笔记的最终归属地，本模板直接写入这里，**不经过** `20 - Inputs`。原因是交给 Inputs Bell 的「按 frontmatter 移动」处理，学者笔记会被归档到 `20 - Inputs/Clippings` 而非 `30 - Metadata/Scholars`。如你的库结构不同，可调整模板的 `path` 字段。
 - 正文含一个指向 `[[学者刷新工作流]]` 的库内链接（记录动态刷新约定），未建该笔记时链接为空链，不影响其他内容。
 
 ## Frontmatter 字段（schema）

--- a/scholar/scholar-clipper.json
+++ b/scholar/scholar-clipper.json
@@ -110,6 +110,6 @@
 		"/^https?:\\/\\/[^\\/?#]+\\.(?:edu(?:\\.[a-z]{2})?|ac\\.[a-z]{2}|mpg\\.de)\\/(?:[^?#]*\\/)?(?:people|person|persons|profile|profiles|faculty|staff|teacher|teachers|members?|szdw|jsdw|rcdw)(?:[\\/?]|\\.html?|$)/"
 	],
 	"noteNameFormat": "{{\"当前学者的名与姓\"}}",
-	"path": "20 - Inputs",
+	"path": "30 - Metadata/Scholars",
 	"context": "请阅读 {{fullHtml}} 并填写所需的各项信息。注意：在 Google Scholar 等聚合页面上，页面可能同时包含当前登录用户的账号信息（如其 Gmail 地址），请只提取被展示学者本人的信息，忽略浏览者本人的账号。"
 }


### PR DESCRIPTION
学者笔记的最终归属地是 `30 - Metadata/Scholars`，但之前模板剪藏到 `20 - Inputs`、交给 Inputs Bell 按 frontmatter 归档，实际会落到 `20 - Inputs/Clippings`。

- `scholar/scholar-clipper.json`：`path` 改为 `30 - Metadata/Scholars`
- `schema/clipper-template.schema.json`：`path` 由 const 放宽为 enum（`20 - Inputs` / `30 - Metadata/Scholars`）
- 三处 README 同步说明（豆瓣模板仍走 `20 - Inputs`）

`npm run validate` 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)